### PR TITLE
Adds button top separator via borderWidth

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -192,7 +192,10 @@ class ActionSheet extends React.Component {
         key={index}
         activeOpacity={1}
         underlayColor={buttonUnderlayColor}
-        style={buttonBoxStyle}
+        style={[
+          buttonBoxStyle,
+          index !== this.props.cancelButtonIndex && styles.topSeparator
+        ]}
         onPress={() => this.hide(index)}
       >
         {React.isValidElement(title) ? (

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -49,13 +49,16 @@ export default {
     fontSize: 12,
   },
   buttonBox: {
-    marginTop: hairlineWidth,
     alignItems: 'center',
     justifyContent: 'center',
     height: 62,
     backgroundColor: 'white',
     borderBottomLeftRadius: 20,
     borderBottomRightRadius: 20,
+  },
+  topSeparator: {
+    borderTopWidth: 0.75,
+    borderColor: "#E1E4EA",
   },
   buttonText: {
     fontSize: 18,


### PR DESCRIPTION
This is because using marginTop: hairlineWidth brings inconsistencies with different screen densities and operative systems.